### PR TITLE
add license title

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,3 +1,5 @@
+ISC License
+
 Copyright (c) 2013-2014, Aaron Gallagher <_@habnab.it>
 
 Permission to use, copy, modify, and/or distribute this software for any


### PR DESCRIPTION
It's not strictly required, but it's useful metadata, and part of the recommended license template text (see http://choosealicense.com/licenses/isc/ and https://opensource.org/licenses/isc-license)
